### PR TITLE
Enable HTTP Local API Calls Without Internet Connection

### DIFF
--- a/lib/api/custom_connection_interceptor.dart
+++ b/lib/api/custom_connection_interceptor.dart
@@ -1,0 +1,21 @@
+import 'package:dio/dio.dart';
+
+class CustomConnectionInterceptor extends Interceptor {
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    // Check if the URL is using HTTP protocol and is a local address
+    final bool isHttpProtocol = options.uri.scheme == 'http';
+    final bool isLocalHost = options.uri.host.contains('local') ||
+        options.uri.host.contains('localhost') ||
+        options.uri.host.contains('127.0.0.1') ||
+        options.uri.host.contains('api-local');
+
+    // If it's HTTP and local, mark it with a custom property
+    if (isHttpProtocol && isLocalHost) {
+      // Add a custom property to options to mark as local HTTP request
+      options.extra['isLocalHttpRequest'] = true;
+    }
+
+    return handler.next(options);
+  }
+}

--- a/lib/api/custom_http_client_adapter.dart
+++ b/lib/api/custom_http_client_adapter.dart
@@ -1,0 +1,51 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:dio/io.dart';
+import 'package:flutter/foundation.dart';
+
+class CustomHttpClientAdapter extends IOHttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    // Check if this is a local HTTP request (marked by our interceptor)
+    final bool isLocalHttpRequest = options.extra['isLocalHttpRequest'] == true;
+
+    if (isLocalHttpRequest) {
+      // For local HTTP requests, use a more permissive HttpClient
+      final httpClient = HttpClient();
+
+      // Bypass certificate checks for local development
+      httpClient.badCertificateCallback =
+          (X509Certificate cert, String host, int port) => true;
+
+      // Override the createHttpClient to use our custom client
+      createHttpClient = () => httpClient;
+    }
+
+    try {
+      return await super.fetch(options, requestStream, cancelFuture);
+    } catch (e) {
+      if (isLocalHttpRequest && e is SocketException) {
+        // For local HTTP requests with socket exceptions,
+        // we can create a custom response indicating local server is not running
+        return ResponseBody(
+          Stream.value(Uint8List.fromList(
+              '{"message": "Local server unavailable"}'.codeUnits)),
+          503, // Service Unavailable
+          headers: {
+            HttpHeaders.contentTypeHeader: ['application/json'],
+          },
+          isRedirect: false,
+          redirects: [],
+          statusMessage: 'Local Server Unavailable',
+        );
+      }
+      // For other errors, rethrow
+      rethrow;
+    }
+  }
+}


### PR DESCRIPTION
## Problem
Currently, our Dio client throws internet connection errors for local HTTP API calls when there is no internet connectivity. This prevents the app from functioning properly when working with local development servers in offline mode.

## Solution
I've implemented a custom solution that allows HTTP local API calls to proceed regardless of internet connectivity, while maintaining normal behavior for HTTPS calls:

1. Added `CustomConnectionInterceptor` to identify and mark local HTTP requests
2. Created `CustomHttpClientAdapter` to handle local requests differently:
   - Bypasses certificate validation for local development
   - Provides graceful error handling for local server unavailability
3. Updated `ApiHelper` to use these new components
4. Modified `AuthInterceptor` to respect local HTTP request settings

## Testing
- Tested with internet connection: both HTTP and HTTPS calls work as expected
- Tested without internet connection: local HTTP calls to http://api-local.ebono.com/store/ still work
- Verified error messages are clear when the local server is unavailable

## Notes
This change only affects how we handle HTTP calls to local endpoints. All other API calls maintain their existing behavior and error handling.