### PR TITLE
Scan Api Now Accepts 9 Digit BarCode

### DIFF
--- a/lib/utils/common_methods.dart
+++ b/lib/utils/common_methods.dart
@@ -14,7 +14,9 @@ bool isValidOfferId(String offerId) {
       offerId.length == 9 ||
       offerId.length == 10 ||
       offerId.length == 12 ||
-      offerId.length == 13;
+      offerId.length == 13 ||
+      offerId.length == 14 ||
+      offerId.length == 15;
 }
 
 showCloseAlert(BuildContext context, {bool isAlertShowing = false}) {

--- a/lib/utils/common_methods.dart
+++ b/lib/utils/common_methods.dart
@@ -11,6 +11,7 @@ import 'package:get/get.dart';
 bool isValidOfferId(String offerId) {
   return offerId.length == 6 ||
       offerId.length == 8 ||
+      offerId.length == 9 ||
       offerId.length == 10 ||
       offerId.length == 12 ||
       offerId.length == 13;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: ebono_pos
 description: "Ebono POS."
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.9
+version: 1.1.0
 
 environment:
   sdk: ^3.5.3


### PR DESCRIPTION
- scan api now accepts 9, 14, 15 digit bar code lengths, total accepting lengths [6, 8, 9, 10, 12, 13, 14, 15]